### PR TITLE
Relax bokbasen/php-sdk-auth version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": ">=7.1",
     "ext-json": "*",
-    "bokbasen/php-sdk-auth": "^2",
+    "bokbasen/php-sdk-auth": "^2|^3",
     "php-http/client-implementation": "^1.0",
     "php-http/httplug": "^2.0",
     "php-http/message-factory": "^1.0",


### PR DESCRIPTION
We need to be able to use higher version of php-api-client for PHP 8 compatibility.