### PR TITLE
Change the settHttpClient argument type to ClientInterface

### DIFF
--- a/src/ApiClient/Client.php
+++ b/src/ApiClient/Client.php
@@ -2,7 +2,7 @@
 
 namespace Bokbasen\ApiClient;
 
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Bokbasen\Auth\Login;
 use Psr\Http\Message\StreamInterface;
@@ -70,7 +70,7 @@ class Client
         return $this->caller;
     }
 
-    public function setHttpClient(HttpClient $httpClient): void
+    public function setHttpClient(ClientInterface $httpClient): void
     {
         $this->getCaller()->setHttpClient($httpClient);
     }


### PR DESCRIPTION
The `setHttpClient` in the `Caller` class already uses `Psr\Http\Client\ClientInterface` as the argument type, the same should be updated in the `Client` class.